### PR TITLE
Prog_utils: add time.h include

### DIFF
--- a/Prog_utils/random.c
+++ b/Prog_utils/random.c
@@ -23,6 +23,7 @@
 #endif
 
 #include <stdlib.h>
+#include <time.h>
 
 static  VIO_BOOL  initialized = FALSE;
 


### PR DESCRIPTION
The build for bicpl in [nixpkgs](https://github.com/NixOS/nixpkgs) has been broken for some time.

The `apple-develop` branch fixes two of the issues - however, a missing `time.h` still prevents a build without additional patches.

I would like to get this into upstream to avoid having to maintain a separate patch just for one line.